### PR TITLE
fix(renovate): apt packages regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
         ".github/apt-packages.txt"
       ],
       "matchStrings": [
-        "^(?<depName>[a-z0-9\\-\\.]+)=(?<currentValue>[^\\s]+)"
+        "^(?<depName>[a-z0-9\\-\\.]+)=(?<currentValue>[^\\s]+)$"
       ],
       "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu/?release=noble&components=main,contrib&binaryArch=amd64",
       "datasourceTemplate": "deb"


### PR DESCRIPTION
This pull request includes a small change to the `renovate.json` file. The change ensures that the match string for dependencies ends with the end-of-line character.

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L13-R13): Updated the `matchStrings` pattern to include the end-of-line character ` at the end of the regex.