### PR TITLE
fix(renovate): simplized renovate regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
         ".github/apt-packages.txt"
       ],
       "matchStrings": [
-        "^(?<depName>[a-z0-9\\-\\.]+)=(?<currentValue>[^\\s]+)$"
+        "^(?<depName>.*?)=(?<currentValue>.*?)"
       ],
       "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu/?release=noble&components=main,contrib&binaryArch=amd64",
       "datasourceTemplate": "deb"


### PR DESCRIPTION
This pull request includes a change to the `renovate.json` file to improve the flexibility of the `matchStrings` pattern for dependency matching.

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L13-R13): Modified the `matchStrings` pattern to use non-greedy matching for `depName` and `currentValue` to allow for more flexible dependency name and value extraction.