### PR TITLE
fix:(renovate): removed leading caret regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
         ".github/apt-packages.txt"
       ],
       "matchStrings": [
-        "^(?<depName>.*?)=(?<currentValue>.*?)"
+        "(?<depName>.*?)=(?<currentValue>.*?)"
       ],
       "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu/?release=noble&components=main,contrib&binaryArch=amd64",
       "datasourceTemplate": "deb"


### PR DESCRIPTION
This pull request includes a small change to the `renovate.json` file. The change modifies the `matchStrings` pattern to remove the leading caret (`^`) character.