### PR TITLE
fix(renovate): fixed fileMatch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
     {
       "customType": "regex",
       "fileMatch": [
-        ".github/apt-packages.txt"
+        "apt-packages.txt"
       ],
       "matchStrings": [
         "(?<depName>.*?)=(?<currentValue>.*?)"


### PR DESCRIPTION
This pull request includes a minor change to the `renovate.json` file. The change updates the `fileMatch` pattern to match `apt-packages.txt` directly instead of looking for it within the `.github` directory.

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L10-R10): Updated the `fileMatch` pattern to match `apt-packages.txt` directly.