### PR TITLE
fix(renovate): change matchStrings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
         "apt-packages.txt"
       ],
       "matchStrings": [
-        "(?<depName>.*?)=(?<currentValue>.*?)"
+        "(?<depName>.+)=(?<currentValue>.+)"
       ],
       "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu/?release=noble&components=main,contrib&binaryArch=amd64",
       "datasourceTemplate": "deb"


### PR DESCRIPTION
This pull request includes a minor change to the `renovate.json` file. The change updates the regular expression pattern used to match dependency names and current values.

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L13-R13): Updated the `matchStrings` pattern to use `.+` instead of `.*?` for both `depName` and `currentValue` to ensure proper matching.