### PR TITLE
feat: 魚の4コマのRSS配信機能を追加

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import ZennChangelog from './services/zenn-changelog'
 import Dev1and from './services/dev1and'
 import TdrUpdates from './services/tdr-updates'
 import PopTeamEpic from './services/pop-team-epic'
+import Fish4Koma from './services/fish-4koma'
 
 async function generateRSSService(service: BaseService) {
   const filename = service.constructor.name
@@ -69,6 +70,7 @@ async function generateRSS() {
     new Dev1and(),
     new TdrUpdates(),
     new PopTeamEpic(),
+    new Fish4Koma(),
   ]
   const promises: Promise<void>[] = services.map((service) =>
     generateRSSService(service).catch((error: unknown) => {

--- a/src/services/fish-4koma.ts
+++ b/src/services/fish-4koma.ts
@@ -1,0 +1,184 @@
+import { BaseService } from '@/base-service'
+import { Logger } from '@book000/node-utils'
+import CollectResult, { Item } from '@/model/collect-result'
+import ServiceInformation from '@/model/service-information'
+import axios from 'axios'
+import * as cheerio from 'cheerio'
+import fs from 'node:fs'
+import crypto from 'node:crypto'
+import sharp from 'sharp'
+import { XMLParser } from 'fast-xml-parser'
+
+export default class Fish4Koma extends BaseService {
+  information(): ServiceInformation {
+    return {
+      title: '魚の4コマ',
+      link: 'https://nyopenasu.livedoor.blog/',
+      description: '魚の4コマ ニョペ茄子',
+      image: {
+        url: 'https://livedoor.blogimg.jp/nyopenasu/imgs/d/0/d01f1d67.jpg',
+        title: '魚の4コマ',
+        link: 'https://nyopenasu.livedoor.blog/',
+      },
+      generator: 'book000/rss-deliver',
+      language: 'ja',
+    }
+  }
+
+  async collect(): Promise<CollectResult> {
+    const logger = Logger.configure('Fish4Koma::collect')
+
+    const response = await axios.get(
+      'https://nyopenasu.livedoor.blog/index.rdf',
+      {
+        validateStatus: () => true,
+      }
+    )
+    if (response.status !== 200) {
+      logger.warn(`❗ Failed to fetch RSS feed (${response.status})`)
+      return {
+        status: false,
+        items: [],
+      }
+    }
+
+    const parser = new XMLParser({
+      ignoreAttributes: false,
+      parseAttributeValue: false,
+    })
+    const parsed = parser.parse(response.data) as {
+      'rdf:RDF': {
+        channel: unknown
+        item?: {
+          title: string
+          link: string
+          description: string
+          'dc:date': string
+        }[]
+      }
+    }
+    const rssItems = parsed['rdf:RDF'].item
+
+    if (!rssItems || rssItems.length === 0) {
+      logger.warn('❗ No items found in RSS feed')
+      return {
+        status: false,
+        items: [],
+      }
+    }
+
+    const items: Item[] = []
+    for (const rssItem of rssItems) {
+      const itemUrl = rssItem.link
+      logger.info(`📃 Processing: ${rssItem.title} - ${itemUrl}`)
+
+      // 記事の詳細ページを取得
+      const itemResponse = await axios.get(itemUrl, {
+        validateStatus: () => true,
+      })
+      if (itemResponse.status !== 200) {
+        logger.warn(`❗ Failed to fetch item page (${itemResponse.status})`)
+        continue
+      }
+
+      const $ = cheerio.load(itemResponse.data)
+
+      // 記事本文から画像を抽出
+      const articleBody = $('.article-body-inner')
+      const images: string[] = []
+
+      articleBody.find('img').each((_, element) => {
+        const src = $(element).attr('src')
+        if (src?.includes('livedoor.blogimg.jp')) {
+          // サムネイルの場合、元画像URLに変換
+          const fullImageUrl = src.replace(/-s$/, '')
+          images.push(fullImageUrl)
+        }
+      })
+
+      // リンクから元画像を取得
+      articleBody.find('a').each((_, element) => {
+        const href = $(element).attr('href')
+        if (
+          href &&
+          href.includes('livedoor.blogimg.jp') &&
+          /\.(jpg|jpeg|png|gif)$/i.test(href) &&
+          !images.includes(href)
+        ) {
+          images.push(href)
+        }
+      })
+
+      if (images.length === 0) {
+        logger.warn(`❗ No images found for: ${rssItem.title}`)
+        continue
+      }
+
+      // 画像を保存
+      if (!fs.existsSync('output/fish4koma/')) {
+        fs.mkdirSync('output/fish4koma/', { recursive: true })
+      }
+
+      const savedImageUrls: string[] = []
+      for (const imageUrl of images) {
+        try {
+          const imageResponse = await axios.get(imageUrl, {
+            responseType: 'arraybuffer',
+            validateStatus: () => true,
+          })
+          if (imageResponse.status !== 200) {
+            logger.warn(`❗ Failed to download image: ${imageUrl}`)
+            continue
+          }
+
+          const buffer = Buffer.from(imageResponse.data)
+
+          // 画像をトリミングして余白を追加
+          const processedBuffer = await sharp(buffer)
+            .trim()
+            .extend({
+              top: 10,
+              bottom: 10,
+              left: 10,
+              right: 10,
+              background: { r: 255, g: 255, b: 255, alpha: 1 },
+            })
+            .toBuffer()
+
+          const hash = this.hash(processedBuffer)
+          const outputPath = `output/fish4koma/${hash}.jpg`
+          fs.writeFileSync(outputPath, processedBuffer)
+
+          savedImageUrls.push(
+            `https://book000.github.io/rss-deliver/fish4koma/${hash}.jpg`
+          )
+        } catch (error) {
+          logger.warn(`❗ Error processing image ${imageUrl}: ${String(error)}`)
+        }
+      }
+
+      if (savedImageUrls.length > 0) {
+        items.push({
+          title: rssItem.title,
+          link: itemUrl,
+          description: rssItem.description,
+          'content:encoded': savedImageUrls
+            .map((url) => `<img src="${url}">`)
+            .join('<br>'),
+          pubDate: rssItem['dc:date'],
+        })
+      }
+    }
+
+    return {
+      status: true,
+      items,
+    }
+  }
+
+  hash(buffer: Buffer): string {
+    const hash = crypto.createHash('md5')
+    hash.update(buffer)
+    return hash.digest('hex')
+  }
+}


### PR DESCRIPTION
## Summary
- 魚の4コマ（https://nyopenasu.livedoor.blog/）のRSS配信機能を実装
- 記事内の画像を抽出して保存・配信する機能を追加
- ポプテピピックと同様の実装パターンに従って開発

## Test plan
- [x] Lintチェックがパスすることを確認
- [ ] 実際にRSSフィードが生成されることを確認
- [ ] 画像が正しく抽出・保存されることを確認
- [ ] 生成されたRSSフィードが有効であることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)