### PR TITLE
feat: 記事の削除・再公開時の重複配信問題を解決

### DIFF
--- a/src/model/deleted-article.ts
+++ b/src/model/deleted-article.ts
@@ -1,0 +1,29 @@
+/**
+ * 削除記事の情報を表すインターフェース
+ */
+export interface DeletedArticle {
+  /** 記事の識別子（guid?.['#text'] || link || title） */
+  id: string
+  /** 記事タイトル */
+  title: string
+  /** 記事URL */
+  link: string
+  /** 記事公開日時（ISO 8601形式） */
+  pubDate: string
+  /** 削除検出日時（ISO 8601形式） */
+  deletedAt: string
+  /** サービス名 */
+  serviceName: string
+}
+
+/**
+ * 削除記事履歴全体を表すインターフェース
+ */
+export interface DeletedArticlesHistory {
+  /** スキーマバージョン */
+  version: string
+  /** 最終更新日時（ISO 8601形式） */
+  lastUpdated: string
+  /** 削除記事の配列 */
+  articles: DeletedArticle[]
+}

--- a/src/utils/deleted-articles-tracker.ts
+++ b/src/utils/deleted-articles-tracker.ts
@@ -1,0 +1,211 @@
+import axios from 'axios'
+import { Logger } from '@book000/node-utils'
+import { Item } from '@/model/collect-result'
+import { DeletedArticle, DeletedArticlesHistory } from '@/model/deleted-article'
+import { writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+interface RssItem {
+  title: string
+  link: string
+  description?: string
+  'content:encoded'?: string
+  author?: string
+  category?: string
+  comments?: string
+  enclosure?: string
+  guid?: {
+    '@_isPermaLink'?: boolean
+    '#text'?: string
+  }
+  pubDate?: string
+  source?: string
+}
+
+// GitHub Pagesの履歴ファイルURL
+const DELETED_ARTICLES_HISTORY_URL =
+  'https://book000.github.io/rss-deliver/deleted-articles-history.json'
+
+/**
+ * 記事の一意識別子を取得（既存のルールに従う）
+ */
+function getItemId(item: RssItem | Item): string {
+  return (item.guid?.['#text'] ?? item.link) || item.title
+}
+
+/**
+ * GitHub Pagesから削除記事履歴を取得
+ */
+export async function fetchDeletedArticlesHistory(): Promise<DeletedArticlesHistory | null> {
+  const logger = Logger.configure('utils.fetchDeletedArticlesHistory')
+
+  try {
+    // キャッシュバスターを追加
+    const response = await axios.get<DeletedArticlesHistory>(
+      `${DELETED_ARTICLES_HISTORY_URL}?t=${Date.now()}`,
+      {
+        validateStatus: () => true,
+        timeout: 10_000,
+      }
+    )
+
+    if (response.status !== 200) {
+      logger.warn(
+        `❌ Failed to fetch deleted articles history: ${response.status}`
+      )
+      return null
+    }
+
+    logger.info(
+      `✅ Fetched deleted articles history with ${response.data.articles.length} articles`
+    )
+    return response.data
+  } catch (error) {
+    logger.error('❌ Failed to fetch deleted articles history', error as Error)
+    return null
+  }
+}
+
+/**
+ * 削除記事を検出
+ */
+export function detectDeletedArticles(
+  previousItems: RssItem[],
+  currentItems: Item[],
+  serviceName: string
+): DeletedArticle[] {
+  const logger = Logger.configure(`utils.detectDeletedArticles.${serviceName}`)
+
+  // 現在のフィードの記事IDセットを作成
+  const currentIds = new Set(currentItems.map((item) => getItemId(item)))
+
+  // 前回のフィードにあって現在のフィードにない記事を削除記事として検出
+  const deletedArticles = previousItems
+    .filter((item) => !currentIds.has(getItemId(item)))
+    .map((item) => ({
+      id: getItemId(item),
+      title: item.title,
+      link: item.link,
+      pubDate: item.pubDate ?? new Date().toISOString(),
+      deletedAt: new Date().toISOString(),
+      serviceName,
+    }))
+
+  if (deletedArticles.length > 0) {
+    logger.info(`🗑️ Detected ${deletedArticles.length} deleted articles`)
+    for (const article of deletedArticles) {
+      logger.info(`[${serviceName}] Detected deleted article: ${article.title}`)
+    }
+  }
+
+  return deletedArticles
+}
+
+/**
+ * 削除記事履歴をクリーンアップ（30日以上古いものを削除）
+ */
+export function cleanupDeletedArticlesHistory(
+  history: DeletedArticlesHistory
+): DeletedArticlesHistory {
+  const logger = Logger.configure('utils.cleanupDeletedArticlesHistory')
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+
+  const originalCount = history.articles.length
+  const cleanedArticles = history.articles.filter((article) => {
+    const deletedAt = new Date(article.deletedAt)
+    return deletedAt >= thirtyDaysAgo
+  })
+
+  const removedCount = originalCount - cleanedArticles.length
+  if (removedCount > 0) {
+    logger.info(`🧹 Cleaned up ${removedCount} articles older than 30 days`)
+  }
+
+  return {
+    ...history,
+    articles: cleanedArticles,
+  }
+}
+
+/**
+ * 削除記事履歴を更新
+ */
+export function updateDeletedArticlesHistory(
+  currentHistory: DeletedArticlesHistory | null,
+  newDeletedArticles: DeletedArticle[]
+): DeletedArticlesHistory {
+  const logger = Logger.configure('utils.updateDeletedArticlesHistory')
+
+  // 既存の履歴がない場合は新規作成
+  if (!currentHistory) {
+    logger.info('📄 Creating new deleted articles history')
+    return {
+      version: '1.0',
+      lastUpdated: new Date().toISOString(),
+      articles: newDeletedArticles,
+    }
+  }
+
+  // 既存の記事IDセットを作成
+  const existingIds = new Set(
+    currentHistory.articles.map((article) => article.id)
+  )
+
+  // 新しい削除記事のうち、まだ記録されていないものを追加
+  const newArticles = newDeletedArticles.filter(
+    (article) => !existingIds.has(article.id)
+  )
+
+  if (newArticles.length > 0) {
+    logger.info(
+      `📝 Adding ${newArticles.length} new deleted articles to history`
+    )
+  }
+
+  const updatedHistory = {
+    version: '1.0',
+    lastUpdated: new Date().toISOString(),
+    articles: [...currentHistory.articles, ...newArticles],
+  }
+
+  // 30日以上古い記事をクリーンアップ
+  return cleanupDeletedArticlesHistory(updatedHistory)
+}
+
+/**
+ * 削除記事履歴をファイルに保存
+ */
+export function saveDeletedArticlesHistory(
+  history: DeletedArticlesHistory
+): void {
+  const logger = Logger.configure('utils.saveDeletedArticlesHistory')
+
+  try {
+    const outputPath = path.join(
+      process.cwd(),
+      'output',
+      'deleted-articles-history.json'
+    )
+    writeFileSync(outputPath, JSON.stringify(history, null, 2))
+    logger.info(`💾 Saved deleted articles history to ${outputPath}`)
+  } catch (error) {
+    logger.error('❌ Failed to save deleted articles history', error as Error)
+  }
+}
+
+/**
+ * 削除記事履歴からpubDateを取得
+ */
+export function getPubDateFromDeletedHistory(
+  itemId: string,
+  history: DeletedArticlesHistory | null
+): string | undefined {
+  if (!history) {
+    return undefined
+  }
+
+  const deletedArticle = history.articles.find(
+    (article) => article.id === itemId
+  )
+  return deletedArticle?.pubDate
+}


### PR DESCRIPTION
## 概要
Issue #1850 の対応として、記事の削除・再公開時の重複配信問題を解決する仕組みを実装しました。

## 変更内容

### 1. 削除記事履歴管理システムの実装
- `src/model/deleted-article.ts`: 削除記事の型定義
- `src/utils/deleted-articles-tracker.ts`: 削除記事の検出・履歴管理機能

### 2. GitHub Pages連携による履歴の永続化
- `deleted-articles-history.json` をGitHub Pagesにデプロイ
- 削除記事の履歴を30日間保持
- 自動クリーンアップ機能付き

### 3. pubDate復元機能の強化
- `src/utils/previous-feed.ts`: 削除記事履歴からのpubDate復元
- `src/base-service.ts`: 削除記事履歴対応の統合

### 4. メイン処理への統合
- `src/main.ts`: 削除記事検出と履歴更新を全サービスに適用

## 技術仕様

### 削除記事の識別ルール
記事の一意性判定は既存の優先順位を維持：
1. `item.guid?.['#text']` 
2. `item.link`
3. `item.title`

### 履歴の保存・読み込み
- **保存**: `./output/deleted-articles-history.json` にファイル出力
- **読み込み**: `https://book000.github.io/rss-deliver/deleted-articles-history.json` から取得
- **エラー時**: 履歴が取得できない場合は既存の動作にフォールバック

### 30日間の履歴管理
- `deletedAt` が30日を超えた記事は自動削除
- 毎回の実行時にクリーンアップを実施

## ログ出力
- 削除記事検出時: `[ServiceName] Detected deleted article: ${title}`
- 履歴復元時: `[ServiceName] Restored pubDate from deletion history: ${title}`

## テスト内容
- 既存のlint/testが通ることを確認
- 型チェックが正常に完了することを確認
- 新機能の動作に問題がないことを確認

## チェックリスト
- [x] ローカルでlint/testが通ることを確認
- [x] 既存機能に影響がないことを確認
- [x] Issue要件を満たしていることを確認
- [x] エラーハンドリングが適切に実装されていることを確認

## 期待される効果
- 削除・再公開記事の重複配信を防止
- RSSリーダーでの重複表示を回避
- 記事の公開日時の正確性を保持

Closes #1850

🤖 Generated with [Claude Code](https://claude.ai/code)