### PR TITLE
fix: pnpm v11 のビルドスクリプト承認設定を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,11 +59,6 @@
         "x64",
         "arm64"
       ]
-    },
-    "onlyBuiltDependencies": [
-      "canvas",
-      "esbuild",
-      "sharp"
-    ]
+    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  canvas: true
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
## 概要

pnpm v11 へのアップデートに伴い、ビルドスクリプトのデフォルトブロック機能への対応を行います。

## 変更内容

pnpm v11 では、セキュリティ向上のためパッケージのビルドスクリプトがデフォルトでブロックされるようになりました。これにより以下のエラーが発生します:

- `[ERR_PNPM_IGNORED_BUILDS]`: `pnpm install` でビルドスクリプトがブロックされる

### 修正

`pnpm-workspace.yaml` に `allowBuilds` を追加し、canvas・esbuild・sharp のビルドスクリプトを明示的に許可します。

## 関連

- book000/book000#108

🤖 Generated with [Claude Code](https://claude.com/claude-code)