### PR TITLE
fix: fast-xml-parser の非推奨 XMLBuilder を fast-xml-builder パッケージに移行

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
         "arm64"
       ]
     }
+  },
+  "dependencies": {
+    "fast-xml-builder": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-n": "18.0.1",
     "eslint-plugin-promise": "7.3.0",
+    "fast-xml-builder": "^1.2.0",
     "fast-xml-parser": "5.6.0",
     "node-ical": "0.26.1",
     "pdfjs-dist": "5.7.284",
@@ -60,8 +61,5 @@
         "arm64"
       ]
     }
-  },
-  "dependencies": {
-    "fast-xml-builder": "^1.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      fast-xml-builder:
-        specifier: ^1.2.0
-        version: 1.2.0
     devDependencies:
       '@book000/eslint-config':
         specifier: 1.14.40
@@ -42,6 +38,9 @@ importers:
       eslint-plugin-promise:
         specifier: 7.3.0
         version: 7.3.0(eslint@10.4.0)
+      fast-xml-builder:
+        specifier: ^1.2.0
+        version: 1.2.0
       fast-xml-parser:
         specifier: 5.6.0
         version: 5.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      fast-xml-builder:
+        specifier: ^1.2.0
+        version: 1.2.0
     devDependencies:
       '@book000/eslint-config':
         specifier: 1.14.40

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
-import { XMLBuilder, XMLParser } from 'fast-xml-parser'
+import { Builder as XMLBuilder } from 'fast-xml-builder'
+import { XMLParser } from 'fast-xml-parser'
 import fs from 'node:fs'
 import { BaseService } from './base-service'
 import { Logger } from '@book000/node-utils'


### PR DESCRIPTION
## 変更概要

`fast-xml-parser` v5.8.0 で `XMLBuilder` が `@deprecated` となり、独立パッケージ `fast-xml-builder` への移行が推奨されるようになった。これにより、Renovate PR #2376 の Node CI が以下のエラーで失敗していた。

```
[rss-deliver lint:eslint] 30:23 error `XMLBuilder` is deprecated. Use npm package 'fast-xml-builder' instead @typescript-eslint/no-deprecated
```

## 変更内容

### `src/main.ts`

- `XMLBuilder` のインポート元を `fast-xml-parser` から `fast-xml-builder` に変更
- `XMLParser` は引き続き `fast-xml-parser` から使用（非推奨ではないため変更なし）
- `fast-xml-builder` の `Builder` を `XMLBuilder` としてエイリアスインポートし、既存コードの変更を最小限に抑えた

### `package.json`

- `fast-xml-builder@^1.2.0` を `dependencies` に追加

### `pnpm-lock.yaml`

- `fast-xml-builder` 追加に伴うロックファイル更新

## 動作確認

- TypeScript コンパイル (`npx tsc --noEmit`) エラーなし
- ESLint (`pnpm run lint:eslint`) エラーなし（`@typescript-eslint/no-deprecated` 警告が解消された）

## 関連

- Renovate PR #2376: `update dependency fast-xml-parser to v5.8.0`
- `fast-xml-builder` npm: https://www.npmjs.com/package/fast-xml-builder