### PR TITLE
fix(deps): fast-xml-builder の named import を default import に変更

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Builder as XMLBuilder } from 'fast-xml-builder'
+import XMLBuilder from 'fast-xml-builder'
 import { XMLParser } from 'fast-xml-parser'
 import fs from 'node:fs'
 import { BaseService } from './base-service'


### PR DESCRIPTION
## 概要

`fast-xml-builder@1.2.0` の ESM モジュールは `default export` のみを提供しており、`{ Builder }` という named export は存在しない。

Renovate による `fast-xml-parser@5.8.0` へのアップグレード（#2376）以降、`fast-xml-parser` は `XMLBuilder` を `fast-xml-builder` パッケージに移管し、以下の re-export 構造になった：

```
fast-xml-parser/src/xmlbuilder/json2xml.js
  └─ import XMLBuilder from 'fast-xml-builder'   ← default export
     export default XMLBuilder
     export * from 'fast-xml-builder'             ← named export なし
```

tsx (esbuild) が import chain を追跡・最適化した結果、以下のコードを生成：

```js
import { Builder as XMLBuilder } from 'fast-xml-builder'  // ← named export が存在しない
```

これが `SyntaxError: The requested module 'fast-xml-builder' does not provide an export named 'Builder'` の原因。

## 変更内容

`src/main.ts` の import を named import から default import に変更：

```diff
-import { Builder as XMLBuilder } from 'fast-xml-builder'
+import XMLBuilder from 'fast-xml-builder'
```

## 関連

- 原因となった CI 失敗: https://github.com/book000/rss-deliver/actions/runs/26321991009
- `fast-xml-parser` アップグレード PR: #2376

🤖 Generated with [Claude Code](https://claude.ai/code)