### PR TITLE
fix(tsconfig): TypeScript v6.0 対応のため tsconfig.json を修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,11 +23,10 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
     "newLine": "LF",
+    "types": ["node"],
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## 変更内容

TypeScript v6.0 アップグレード時に適用された一時的な回避策を正式な修正に置き換えます。

### 変更点

- `baseUrl: "."` を削除し、`paths` のパスを相対パス (`./src/*`) に更新
  - `baseUrl` が存在しない場合、パスは相対パスで指定する必要があるため
- `ignoreDeprecations: "6.0"` を削除
  - この設定は TypeScript 7.0 で機能しなくなるため
- `types: ["node"]` を追加
  - TypeScript 6.0 で廃止された `@types/node` の自動ロードに対応するため

### 動作確認

- `pnpm lint:tsc` (TypeScript コンパイルエラーなし) ✅
- `pnpm lint` (全 lint チェック通過) ✅

Fixes #2468