### PR TITLE
fix: devcontainer から pnpm approve-builds を削除

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
   "otherPortsAttributes": {
     "onAutoForward": "silent"
   },
-  "postCreateCommand": "sudo npm uninstall -g pnpm yarn && sudo git config --system --add safe.directory ${containerWorkspaceFolder} && sudo chown node node_modules .pnpm-store && sudo npm install -g corepack@latest && sudo corepack enable && corepack install && pnpm install && pnpm approve-builds",
+  "postCreateCommand": "sudo npm uninstall -g pnpm yarn && sudo git config --system --add safe.directory ${containerWorkspaceFolder} && sudo chown node node_modules .pnpm-store && sudo npm install -g corepack@latest && sudo corepack enable && corepack install && pnpm install",
   "postStartCommand": "pnpm install",
   "waitFor": "postCreateCommand",
   "mounts": [


### PR DESCRIPTION
## 概要

- devcontainer の `postCreateCommand` から `pnpm approve-builds` を削除

## 関連 Issue

- https://github.com/book000/book000/issues/119

🤖 Generated with [Claude Code](https://claude.com/claude-code)