### PR TITLE
fix(lint): eslint-config 1.15.44 の unicorn ルールに対応

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import FF14LodestoneUpdate from './services/ff14-lodestone-update'
 import PhysicalUpLettuceClub from './services/physical-up-lettuce-club'
 import Rikei2LettuceClub from './services/rikei-2-lettuce-club'
 import ZennChangelog from './services/zenn-changelog'
-import Dev1and from './services/dev1and'
+import Development1and from './services/development1and'
 import TdrUpdates from './services/tdr-updates'
 import PopTeamEpic from './services/pop-team-epic'
 import Fish4Koma from './services/fish-4koma'
@@ -81,7 +81,7 @@ async function generateRSS() {
     new FF14LodestoneObstacle(),
     new PhysicalUpLettuceClub(),
     new Rikei2LettuceClub(),
-    new Dev1and(),
+    new Development1and(),
     new TdrUpdates(),
     new PopTeamEpic(),
     new Fish4Koma(),
@@ -190,7 +190,10 @@ function generateList() {
     .filter((s) => s !== null)
   fs.writeFileSync(
     'output/index.html',
-    template.replace('{{ RSS-FILES }}', '<ul>' + list.join('\n') + '</ul>')
+    template.replace(
+      '{{ RSS-FILES }}',
+      () => '<ul>' + list.join('\n') + '</ul>'
+    )
   )
   logger.info('✅ Generated list')
 }

--- a/src/services/development1and.ts
+++ b/src/services/development1and.ts
@@ -43,12 +43,12 @@ interface Data {
   monthly_github: Daily
 }
 
-interface Dev1andFeedResponse {
+interface Development1andFeedResponse {
   last_updated_at: string
   data: Data
 }
 
-export default class Dev1and extends BaseService {
+export default class Development1and extends BaseService {
   information(): ServiceInformation {
     return {
       title: 'Devland',
@@ -65,23 +65,20 @@ export default class Dev1and extends BaseService {
   }
 
   async collect(): Promise<CollectResult> {
-    const res = await fetch('https://feed.dev1and.com/api/v1/dashboard')
-    if (res.status !== 200) {
+    const response_ = await fetch('https://feed.dev1and.com/api/v1/dashboard')
+    if (response_.status !== 200) {
       return {
         status: false,
         items: [],
       }
     }
 
-    const response = (await res.json()) as Dev1andFeedResponse
+    const response = (await response_.json()) as Development1andFeedResponse
 
     const lastUpdatedAtRaw = response.last_updated_at
     const lastUpdatedAt = new Date(lastUpdatedAtRaw.replaceAll('/', '-'))
     const lastUpdatedDateText = this.getYearMonthWeek(lastUpdatedAt)
-    const lastUpdatedDate = lastUpdatedDateText
-      .replaceAll('/', '-')
-      .replaceAll('#', '-')
-      .replaceAll(' ', '-')
+    const lastUpdatedDate = lastUpdatedDateText.replaceAll(/[/# ]/g, '-')
 
     const weeklyArticle = response.data.weekly_hit.items.map((item) => {
       return [

--- a/src/services/ff14-lodestone-maintenance.ts
+++ b/src/services/ff14-lodestone-maintenance.ts
@@ -28,17 +28,17 @@ export default class FF14LodestoneMaintenance extends BaseService {
    */
   async collect(): Promise<CollectResult> {
     const logger = Logger.configure('FF14LodestoneMaintenance::collect')
-    const res = await fetch('https://jp.finalfantasyxiv.com/lodestone/')
-    const data = await res.text()
-    if (res.status !== 200 && data.includes('メンテナンス中')) {
+    const response = await fetch('https://jp.finalfantasyxiv.com/lodestone/')
+    const data = await response.text()
+    if (response.status !== 200 && data.includes('メンテナンス中')) {
       logger.info('🚧 FF14 Lodestone is under maintenance')
       return {
         status: false,
         items: [],
       }
     }
-    if (res.status !== 200) {
-      throw new Error(`Failed to fetch: ${res.status}`)
+    if (response.status !== 200) {
+      throw new Error(`Failed to fetch: ${response.status}`)
     }
 
     const $ = cheerio.load(data)

--- a/src/services/ff14-lodestone-news.ts
+++ b/src/services/ff14-lodestone-news.ts
@@ -28,17 +28,17 @@ export default class FF14LodestoneNews extends BaseService {
    */
   async collect(): Promise<CollectResult> {
     const logger = Logger.configure('FF14LodestoneNews::collect')
-    const res = await fetch('https://jp.finalfantasyxiv.com/lodestone/')
-    const data = await res.text()
-    if (res.status !== 200 && data.includes('メンテナンス中')) {
+    const response = await fetch('https://jp.finalfantasyxiv.com/lodestone/')
+    const data = await response.text()
+    if (response.status !== 200 && data.includes('メンテナンス中')) {
       logger.info('🚧 FF14 Lodestone is under maintenance')
       return {
         status: false,
         items: [],
       }
     }
-    if (res.status !== 200) {
-      throw new Error(`Failed to fetch: ${res.status}`)
+    if (response.status !== 200) {
+      throw new Error(`Failed to fetch: ${response.status}`)
     }
 
     const $ = cheerio.load(data)

--- a/src/services/ff14-lodestone-obstacle.ts
+++ b/src/services/ff14-lodestone-obstacle.ts
@@ -28,17 +28,17 @@ export default class FF14LodestoneObstacle extends BaseService {
    */
   async collect(): Promise<CollectResult> {
     const logger = Logger.configure('FF14LodestoneObstacle::collect')
-    const res = await fetch('https://jp.finalfantasyxiv.com/lodestone/')
-    const data = await res.text()
-    if (res.status !== 200 && data.includes('メンテナンス中')) {
+    const response = await fetch('https://jp.finalfantasyxiv.com/lodestone/')
+    const data = await response.text()
+    if (response.status !== 200 && data.includes('メンテナンス中')) {
       logger.info('🚧 FF14 Lodestone is under maintenance')
       return {
         status: false,
         items: [],
       }
     }
-    if (res.status !== 200) {
-      throw new Error(`Failed to fetch: ${res.status}`)
+    if (response.status !== 200) {
+      throw new Error(`Failed to fetch: ${response.status}`)
     }
 
     const $ = cheerio.load(data)

--- a/src/services/ff14-lodestone-update.ts
+++ b/src/services/ff14-lodestone-update.ts
@@ -28,17 +28,17 @@ export default class FF14LodestoneUpdate extends BaseService {
    */
   async collect(): Promise<CollectResult> {
     const logger = Logger.configure('FF14LodestoneUpdate::collect')
-    const res = await fetch('https://jp.finalfantasyxiv.com/lodestone/')
-    const data = await res.text()
-    if (res.status !== 200 && data.includes('メンテナンス中')) {
+    const response = await fetch('https://jp.finalfantasyxiv.com/lodestone/')
+    const data = await response.text()
+    if (response.status !== 200 && data.includes('メンテナンス中')) {
       logger.info('🚧 FF14 Lodestone is under maintenance')
       return {
         status: false,
         items: [],
       }
     }
-    if (res.status !== 200) {
-      throw new Error(`Failed to fetch: ${res.status}`)
+    if (response.status !== 200) {
+      throw new Error(`Failed to fetch: ${response.status}`)
     }
 
     const $ = cheerio.load(data)

--- a/src/services/fish-4koma.ts
+++ b/src/services/fish-4koma.ts
@@ -27,9 +27,9 @@ export default class Fish4Koma extends BaseService {
   async collect(): Promise<CollectResult> {
     const logger = Logger.configure('Fish4Koma::collect')
 
-    const res = await fetch('https://nyopenasu.livedoor.blog/index.rdf')
-    if (res.status !== 200) {
-      logger.warn(`❗ Failed to fetch RSS feed (${res.status})`)
+    const response = await fetch('https://nyopenasu.livedoor.blog/index.rdf')
+    if (response.status !== 200) {
+      logger.warn(`❗ Failed to fetch RSS feed (${response.status})`)
       return {
         status: false,
         items: [],
@@ -40,7 +40,7 @@ export default class Fish4Koma extends BaseService {
       ignoreAttributes: false,
       parseAttributeValue: false,
     })
-    const parsed = parser.parse(await res.text()) as {
+    const parsed = parser.parse(await response.text()) as {
       'rdf:RDF': {
         channel: unknown
         item?: {
@@ -67,23 +67,23 @@ export default class Fish4Koma extends BaseService {
       logger.info(`📃 Processing: ${rssItem.title} - ${itemUrl}`)
 
       // 記事の詳細ページを取得
-      const itemRes = await fetch(itemUrl)
-      if (itemRes.status !== 200) {
-        logger.warn(`❗ Failed to fetch item page (${itemRes.status})`)
+      const itemResponse = await fetch(itemUrl)
+      if (itemResponse.status !== 200) {
+        logger.warn(`❗ Failed to fetch item page (${itemResponse.status})`)
         continue
       }
 
-      const $ = cheerio.load(await itemRes.text())
+      const $ = cheerio.load(await itemResponse.text())
 
       // 記事本文から画像を抽出
       const articleBody = $('.article-body-inner')
       const images: string[] = []
 
       articleBody.find('img').each((_, element) => {
-        const src = $(element).attr('src')
-        if (src?.includes('livedoor.blogimg.jp')) {
+        const source = $(element).attr('src')
+        if (source?.includes('livedoor.blogimg.jp')) {
           // サムネイルの場合、元画像URLに変換
-          const fullImageUrl = src.replace(/-s$/, '')
+          const fullImageUrl = source.replace(/-s$/, '')
           images.push(fullImageUrl)
         }
       })
@@ -111,39 +111,15 @@ export default class Fish4Koma extends BaseService {
         fs.mkdirSync('output/fish4koma/', { recursive: true })
       }
 
-      let largestImageUrl: string | null = null
-      let maxImageSize = 0
-
       // 最大サイズの画像を特定
-      for (const imageUrl of images) {
-        try {
-          const imageRes = await fetch(imageUrl)
-          if (imageRes.status !== 200) {
-            logger.warn(`❗ Failed to download image: ${imageUrl}`)
-            continue
-          }
-
-          const buffer = Buffer.from(await imageRes.arrayBuffer())
-          const metadata = await sharp(buffer).metadata()
-          const imageSize = (metadata.width || 0) * (metadata.height || 0)
-
-          if (imageSize > maxImageSize) {
-            maxImageSize = imageSize
-            largestImageUrl = imageUrl
-          }
-        } catch (error) {
-          logger.warn(
-            `❗ Error checking image size ${imageUrl}: ${String(error)}`
-          )
-        }
-      }
+      const largestImageUrl = await this.findLargestImage(images, logger)
 
       let savedImageUrl: string | null = null
       if (largestImageUrl) {
         try {
-          const imageRes2 = await fetch(largestImageUrl)
-          if (imageRes2.ok) {
-            const buffer = Buffer.from(await imageRes2.arrayBuffer())
+          const imageResponse2 = await fetch(largestImageUrl)
+          if (imageResponse2.ok) {
+            const buffer = Buffer.from(await imageResponse2.arrayBuffer())
 
             // 画像をトリミングして余白を追加
             const processedBuffer = await sharp(buffer)
@@ -191,5 +167,44 @@ export default class Fish4Koma extends BaseService {
     const hash = crypto.createHash('md5')
     hash.update(buffer)
     return hash.digest('hex')
+  }
+
+  /**
+   * 候補画像の中から最大サイズの画像 URL を特定する。
+   * @param images 候補画像 URL のリスト
+   * @param logger ロガー
+   * @returns 最大サイズの画像 URL。取得できるものがなければ null
+   */
+  async findLargestImage(
+    images: string[],
+    logger: Logger
+  ): Promise<string | null> {
+    let largestImageUrl: string | null = null
+    let maxImageSize = 0
+
+    for (const imageUrl of images) {
+      try {
+        const imageResponse = await fetch(imageUrl)
+        if (imageResponse.status !== 200) {
+          logger.warn(`❗ Failed to download image: ${imageUrl}`)
+          continue
+        }
+
+        const buffer = Buffer.from(await imageResponse.arrayBuffer())
+        const metadata = await sharp(buffer).metadata()
+        const imageSize = (metadata.width || 0) * (metadata.height || 0)
+
+        if (imageSize > maxImageSize) {
+          maxImageSize = imageSize
+          largestImageUrl = imageUrl
+        }
+      } catch (error) {
+        logger.warn(
+          `❗ Error checking image size ${imageUrl}: ${String(error)}`
+        )
+      }
+    }
+
+    return largestImageUrl
   }
 }

--- a/src/services/github-events.ts
+++ b/src/services/github-events.ts
@@ -69,9 +69,9 @@ export default class GitHubEvents extends BaseService {
 
     try {
       // ICS ファイルを取得
-      const res = await fetch(ICS_URL)
-      if (res.status !== 200) {
-        logger.error(`❌ Failed to fetch ICS: ${res.status}`)
+      const response = await fetch(ICS_URL)
+      if (response.status !== 200) {
+        logger.error(`❌ Failed to fetch ICS: ${response.status}`)
         return {
           status: false,
           items: [],
@@ -79,7 +79,7 @@ export default class GitHubEvents extends BaseService {
       }
 
       // ICS をパース
-      const calendar = ical.sync.parseICS(await res.text())
+      const calendar = ical.sync.parseICS(await response.text())
 
       // VEVENT のみ抽出
       const events = Object.values(calendar).filter(
@@ -115,7 +115,7 @@ export default class GitHubEvents extends BaseService {
 
         // 開始・終了日時
         if (event.start instanceof Date) {
-          const startStr = event.start.toLocaleString('ja-JP', {
+          const startString = event.start.toLocaleString('ja-JP', {
             timeZone: 'Asia/Tokyo',
             year: 'numeric',
             month: '2-digit',
@@ -123,10 +123,10 @@ export default class GitHubEvents extends BaseService {
             hour: '2-digit',
             minute: '2-digit',
           })
-          contentParts.push(`<p>開始: ${startStr}</p>`)
+          contentParts.push(`<p>開始: ${startString}</p>`)
         }
         if (event.end instanceof Date) {
-          const endStr = event.end.toLocaleString('ja-JP', {
+          const endString = event.end.toLocaleString('ja-JP', {
             timeZone: 'Asia/Tokyo',
             year: 'numeric',
             month: '2-digit',
@@ -134,7 +134,7 @@ export default class GitHubEvents extends BaseService {
             hour: '2-digit',
             minute: '2-digit',
           })
-          contentParts.push(`<p>終了: ${endStr}</p>`)
+          contentParts.push(`<p>終了: ${endString}</p>`)
         }
 
         // 場所

--- a/src/services/physical-up-lettuce-club.ts
+++ b/src/services/physical-up-lettuce-club.ts
@@ -23,11 +23,13 @@ export default class PhysicalUpLettuceClub extends BaseService {
 
   async collect(): Promise<CollectResult> {
     const logger = Logger.configure('PhysicalUpLettuceClub::collect')
-    const res = await fetch('https://www.lettuceclub.net/news/serial/11656/')
-    if (!res.ok) {
-      throw new Error(`Failed to fetch: ${res.status}`)
+    const response = await fetch(
+      'https://www.lettuceclub.net/news/serial/11656/'
+    )
+    if (!response.ok) {
+      throw new Error(`Failed to fetch: ${response.status}`)
     }
-    const $ = cheerio.load(await res.text())
+    const $ = cheerio.load(await response.text())
     const items: Item[] = []
     for (const index of $('div.l-contents ol.p-items__list li.p-items__item')) {
       const item = $(index)
@@ -71,11 +73,11 @@ export default class PhysicalUpLettuceClub extends BaseService {
     images: string[]
     pubDate: string
   } | null> {
-    const res = await fetch(url)
-    if (res.status !== 200) {
+    const response = await fetch(url)
+    if (response.status !== 200) {
       return null
     }
-    const $ = cheerio.load(await res.text())
+    const $ = cheerio.load(await response.text())
 
     const images: string[] = []
     for (const index of $('div.l-contents figure img')) {

--- a/src/services/pop-team-epic.ts
+++ b/src/services/pop-team-epic.ts
@@ -177,21 +177,21 @@ export default class PopTeamEpic extends BaseService {
   } | null> {
     const logger = Logger.configure('PopTeamEpic::fetchTakecomicSeason')
     const takecomicSeriesUrl = 'https://takecomic.jp/series/8f3616ce97c36'
-    const res = await fetch(takecomicSeriesUrl, {
+    const response = await fetch(takecomicSeriesUrl, {
       headers: {
         ...PopTeamEpic.COMMON_HEADERS,
         Accept:
           'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
       },
     })
-    if (res.status !== 200) {
+    if (response.status !== 200) {
       logger.warn(
-        `❗ Failed to fetch takecomic series page (status=${res.status})`
+        `❗ Failed to fetch takecomic series page (status=${response.status})`
       )
       return null
     }
 
-    const $ = cheerio.load(await res.text())
+    const $ = cheerio.load(await response.text())
     const title = $('meta[property="og:title"]').attr('content')?.trim() ?? ''
     const image = PopTeamEpic.normalizeUrl(
       $('meta[property="og:image"]').attr('content') ?? ''
@@ -252,7 +252,7 @@ export default class PopTeamEpic extends BaseService {
         'content:encoded': imageUrls
           .map((url) => `<img src="${url}">`)
           .join('<br>'),
-        ...(date ? { pubDate: date.toUTCString() } : {}),
+        ...(date && { pubDate: date.toUTCString() }),
       })
     }
     return items
@@ -270,9 +270,11 @@ export default class PopTeamEpic extends BaseService {
     logger: Logger
   ): Promise<TakecomicEpisode[]> {
     const rssUrl = `${seriesUrl.replace(/\/$/, '')}/rss`
-    const res = await fetch(rssUrl)
-    if (res.status !== 200) {
-      logger.warn(`❗ Failed to fetch official RSS (${res.status}) ${rssUrl}`)
+    const response = await fetch(rssUrl)
+    if (response.status !== 200) {
+      logger.warn(
+        `❗ Failed to fetch official RSS (${response.status}) ${rssUrl}`
+      )
       return []
     }
 
@@ -281,7 +283,7 @@ export default class PopTeamEpic extends BaseService {
       const parser = new XMLParser({
         ignoreAttributes: false,
       })
-      const rss = parser.parse(await res.text()) as TakecomicRssResponse
+      const rss = parser.parse(await response.text()) as TakecomicRssResponse
       rawItems = rss.rss?.channel?.item
     } catch (error) {
       logger.warn(`❗ Failed to parse official RSS: ${String(error)}`)
@@ -333,20 +335,20 @@ export default class PopTeamEpic extends BaseService {
   ): Promise<string[]> {
     try {
       // エピソードページを取得
-      const res = await fetch(episodeUrl, {
+      const response = await fetch(episodeUrl, {
         headers: {
           ...PopTeamEpic.COMMON_HEADERS,
           Accept:
             'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
         },
       })
-      if (res.status !== 200) {
-        logger.warn(`❗ Failed to fetch episode page (${res.status})`)
+      if (response.status !== 200) {
+        logger.warn(`❗ Failed to fetch episode page (${response.status})`)
         return []
       }
 
       // viewerId を抽出
-      const viewerId = this.extractViewerId(await res.text())
+      const viewerId = this.extractViewerId(await response.text())
       if (!viewerId) {
         logger.warn('❗ viewerId not found in episode page')
         return []
@@ -363,8 +365,9 @@ export default class PopTeamEpic extends BaseService {
 
       // 各ページの画像を取得・復元
       const imageUrls: string[] = []
-      for (let i = 0; i < contentsInfo.totalPages; i++) {
-        const pageData = contentsInfo.result[i] as PageContentInfo | undefined
+      for (let index = 0; index < contentsInfo.totalPages; index++) {
+        const pageData = contentsInfo.result[index] as
+          PageContentInfo | undefined
         if (!pageData) {
           continue
         }
@@ -394,10 +397,10 @@ export default class PopTeamEpic extends BaseService {
    */
   private extractViewerId(html: string): string | null {
     // data-comici-viewer-id 属性から viewerId を探す
-    const dataAttrRegex = /data-comici-viewer-id="([a-f0-9]{32})"/i
-    const dataAttrMatch = dataAttrRegex.exec(html)
-    if (dataAttrMatch?.[1]) {
-      return dataAttrMatch[1]
+    const dataAttributeRegex = /data-comici-viewer-id="([a-f0-9]{32})"/i
+    const dataAttributeMatch = dataAttributeRegex.exec(html)
+    if (dataAttributeMatch?.[1]) {
+      return dataAttributeMatch[1]
     }
 
     // __next_f (React Server Components) から viewerId を探す（フォールバック）
@@ -430,26 +433,26 @@ export default class PopTeamEpic extends BaseService {
     }
 
     // ステップ1: page-to=1 で totalPages を取得
-    const initialParams = new URLSearchParams({
+    const initialParameters = new URLSearchParams({
       'user-id': '',
       'comici-viewer-id': viewerId,
       'page-from': '0',
       'page-to': '1',
     })
-    const initialUrl = `https://takecomic.jp/api/book/contentsInfo?${initialParams.toString()}`
+    const initialUrl = `https://takecomic.jp/api/book/contentsInfo?${initialParameters.toString()}`
 
     logger.info(`📡 Fetching totalPages: viewerId=${viewerId}`)
 
-    const initialRes = await fetch(initialUrl, { headers })
+    const initialResponse = await fetch(initialUrl, { headers })
 
-    if (initialRes.status !== 200) {
+    if (initialResponse.status !== 200) {
       logger.warn(
-        `❌ API error (initial): status=${initialRes.status}, viewerId=${viewerId}`
+        `❌ API error (initial): status=${initialResponse.status}, viewerId=${viewerId}`
       )
       return null
     }
 
-    const initialData = (await initialRes.json()) as ContentsInfoResponse
+    const initialData = (await initialResponse.json()) as ContentsInfoResponse
     const totalPages = initialData.totalPages
     logger.info(`📖 totalPages=${totalPages}`)
 
@@ -459,26 +462,26 @@ export default class PopTeamEpic extends BaseService {
     }
 
     // ステップ2: 全ページを取得
-    const fullParams = new URLSearchParams({
+    const fullParameters = new URLSearchParams({
       'user-id': '',
       'comici-viewer-id': viewerId,
       'page-from': '0',
       'page-to': String(totalPages),
     })
-    const fullUrl = `https://takecomic.jp/api/book/contentsInfo?${fullParams.toString()}`
+    const fullUrl = `https://takecomic.jp/api/book/contentsInfo?${fullParameters.toString()}`
 
-    const fullRes = await fetch(fullUrl, { headers })
+    const fullResponse = await fetch(fullUrl, { headers })
 
-    if (fullRes.status !== 200) {
+    if (fullResponse.status !== 200) {
       logger.warn(
-        `❌ API error (full): status=${fullRes.status}, viewerId=${viewerId}`
+        `❌ API error (full): status=${fullResponse.status}, viewerId=${viewerId}`
       )
       return null
     }
 
     logger.info(`✅ Fetched ${totalPages} pages successfully`)
 
-    return (await fullRes.json()) as ContentsInfoResponse
+    return (await fullResponse.json()) as ContentsInfoResponse
   }
 
   /**
@@ -496,7 +499,7 @@ export default class PopTeamEpic extends BaseService {
   ): Promise<string | null> {
     try {
       // 画像をダウンロード（CloudFront 署名付き URL には適切なヘッダーが必要）
-      const res = await fetch(pageData.imageUrl, {
+      const response = await fetch(pageData.imageUrl, {
         headers: {
           Referer: episodeUrl,
           ...PopTeamEpic.COMMON_HEADERS,
@@ -505,12 +508,12 @@ export default class PopTeamEpic extends BaseService {
         },
       })
 
-      if (res.status !== 200) {
-        logger.warn(`❗ Failed to download image (${res.status})`)
+      if (response.status !== 200) {
+        logger.warn(`❗ Failed to download image (${response.status})`)
         return null
       }
 
-      const scrambledBuffer = Buffer.from(await res.arrayBuffer())
+      const scrambledBuffer = Buffer.from(await response.arrayBuffer())
 
       // スクランブル配列をパース
       let scramble: number[]
@@ -548,7 +551,7 @@ export default class PopTeamEpic extends BaseService {
   ): Promise<Buffer> {
     // グリッドサイズを計算（通常は 4x4 = 16 タイル）
     const gridSize = Math.sqrt(scramble.length)
-    if (!Number.isInteger(gridSize)) {
+    if (!Number.isSafeInteger(gridSize)) {
       // スクランブルなしとして元の画像を返す
       return buffer
     }
@@ -592,21 +595,21 @@ export default class PopTeamEpic extends BaseService {
     // scramble[i] = srcIndex
     // 出力も Column-Major 順序で配置する
     const compositeOperations: sharp.OverlayOptions[] = []
-    let destTileIndex = 0
+    let destinationTileIndex = 0
     for (let c = 0; c < gridSize; c++) {
       for (let r = 0; r < gridSize; r++) {
-        const srcIndex = scramble[destTileIndex]
+        const sourceIndex = scramble[destinationTileIndex]
 
-        if (srcIndex < 0 || srcIndex >= tiles.length) {
+        if (sourceIndex < 0 || sourceIndex >= tiles.length) {
           return buffer
         }
 
         compositeOperations.push({
-          input: tiles[srcIndex],
+          input: tiles[sourceIndex],
           left: c * actualTileWidth,
           top: r * actualTileHeight,
         })
-        destTileIndex++
+        destinationTileIndex++
       }
     }
 
@@ -690,7 +693,7 @@ export default class PopTeamEpic extends BaseService {
       const parsedUrl = new URL(normalizedUrl)
       parsedUrl.search = ''
       parsedUrl.hash = ''
-      return parsedUrl.toString().replace(/\/$/, '')
+      return parsedUrl.href.replace(/\/$/, '')
     } catch {
       return normalizedUrl
     }
@@ -740,14 +743,14 @@ export default class PopTeamEpic extends BaseService {
     }
 
     const imageUrl = PopTeamEpic.normalizeUrl(image)
-    const imageRes = await fetch(imageUrl)
-    if (imageRes.status !== 200) {
+    const imageResponse = await fetch(imageUrl)
+    if (imageResponse.status !== 200) {
       logger.warn(
-        `❗ Failed to download image (${imageRes.status}) ${imageUrl}`
+        `❗ Failed to download image (${imageResponse.status}) ${imageUrl}`
       )
       return null
     }
-    return Buffer.from(await imageRes.arrayBuffer())
+    return Buffer.from(await imageResponse.arrayBuffer())
   }
 
   private parseJstDate(dateText: string): Date | null {
@@ -766,7 +769,7 @@ export default class PopTeamEpic extends BaseService {
       return `https:${url}`
     }
     if (url.startsWith('/')) {
-      return new URL(url, 'https://takecomic.jp').toString()
+      return new URL(url, 'https://takecomic.jp').href
     }
     return url
   }

--- a/src/services/rikei-2-lettuce-club.ts
+++ b/src/services/rikei-2-lettuce-club.ts
@@ -23,8 +23,10 @@ export default class Rikei2LettuceClub extends BaseService {
 
   async collect(): Promise<CollectResult> {
     const logger = Logger.configure('Rikei2LettuceClub::collect')
-    const res = await fetch('https://www.lettuceclub.net/news/serial/12004/')
-    const $ = cheerio.load(await res.text())
+    const response = await fetch(
+      'https://www.lettuceclub.net/news/serial/12004/'
+    )
+    const $ = cheerio.load(await response.text())
     const items: Item[] = []
     for (const index of $('div.l-contents ol.p-items__list li.p-items__item')) {
       const item = $(index)
@@ -68,11 +70,11 @@ export default class Rikei2LettuceClub extends BaseService {
     images: string[]
     pubDate: string
   } | null> {
-    const res = await fetch(url)
-    if (res.status !== 200) {
+    const response = await fetch(url)
+    if (response.status !== 200) {
       return null
     }
-    const $ = cheerio.load(await res.text())
+    const $ = cheerio.load(await response.text())
 
     const images: string[] = []
     for (const index of $('div.l-contents figure img')) {

--- a/src/services/tdr-updates.ts
+++ b/src/services/tdr-updates.ts
@@ -34,7 +34,7 @@ export default class TdrUpdates extends BaseService {
    */
   async collect(): Promise<CollectResult> {
     const logger = Logger.configure('TdrUpdates::collect')
-    const res = await fetch(this.pageUrl, {
+    const response = await fetch(this.pageUrl, {
       headers: {
         'User-Agent':
           'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0',
@@ -49,15 +49,15 @@ export default class TdrUpdates extends BaseService {
         DNT: '1',
       },
     })
-    if (!res.ok) {
-      throw new Error(`Failed to fetch: ${res.status}`)
+    if (!response.ok) {
+      throw new Error(`Failed to fetch: ${response.status}`)
     }
-    const $ = cheerio.load(await res.text())
+    const $ = cheerio.load(await response.text())
     const items: Item[] = []
     for (const element of $('div.listUpdate ul li a')) {
       const anchor = $(element)
       const href = anchor.attr('href') ?? ''
-      const url = new URL(href, this.pageUrl).toString()
+      const url = new URL(href, this.pageUrl).href
       const title = anchor.find('p.txt').text()
       const dateRaw = anchor.find('p.date').text() // 2023.7.24 更新情報
       const year = ('0000' + dateRaw.split('.', 1)[0]).slice(-4)
@@ -103,11 +103,11 @@ export default class TdrUpdates extends BaseService {
   }
 
   async pdf2png(url: string): Promise<string[]> {
-    const res = await fetch(url)
-    if (!res.ok) {
-      throw new Error(`Failed to fetch pdf: ${res.status}`)
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(`Failed to fetch pdf: ${response.status}`)
     }
-    const pdfData = new Uint8Array(await res.arrayBuffer())
+    const pdfData = new Uint8Array(await response.arrayBuffer())
     const pdfDocument = await pdfjs.getDocument({ data: pdfData }).promise
 
     if (!fs.existsSync('output/tdr-updates/')) {

--- a/src/services/zenn-changelog.ts
+++ b/src/services/zenn-changelog.ts
@@ -98,14 +98,14 @@ export default class ZennChangelog extends BaseService {
     const parser = new XMLParser({
       ignoreAttributes: false,
     })
-    const res = await fetch('https://info.zenn.dev/rss/feed.xml')
-    if (res.status !== 200) {
+    const response = await fetch('https://info.zenn.dev/rss/feed.xml')
+    if (response.status !== 200) {
       return {
         status: false,
         items: [],
       }
     }
-    const oldFeed: ZeenChangelogResponse = parser.parse(await res.text())
+    const oldFeed: ZeenChangelogResponse = parser.parse(await response.text())
     const items: Item[] = []
     for (const item of oldFeed.rss.channel.item.slice(0, 10)) {
       // 直近の 10 件を取得

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -3,5 +3,4 @@ declare global {
   interface SVGGraphics {}
 }
 
-// eslint-disable-next-line unicorn/require-module-specifiers
 export {}

--- a/src/utils/article-fetcher.ts
+++ b/src/utils/article-fetcher.ts
@@ -73,18 +73,18 @@ interface ArticleCacheData {
  * ヘッダー・フッター・ナビゲーション等を除去してメインエリアの HTML を返す。
  * @param html ページの HTML 文字列
  * @param contentSelector メインコンテンツのセレクタ (デフォルト: '#mainArea')
- * @param removeSelectors 除去するセレクタのリスト (デフォルト: 標準的なノイズ要素)
+ * @param selectorsToRemove 除去するセレクタのリスト (デフォルト: 標準的なノイズ要素)
  * @returns 抽出したコンテンツ HTML
  */
 export function extractArticleContent(
   html: string,
   contentSelector: string = DEFAULT_CONTENT_SELECTOR,
-  removeSelectors: string[] = DEFAULT_REMOVE_SELECTORS
+  selectorsToRemove: string[] = DEFAULT_REMOVE_SELECTORS
 ): string {
   const $ = cheerio.load(html)
 
   // ナビゲーション・ヘッダー・フッターなどのノイズ要素を除去する
-  for (const selector of removeSelectors) {
+  for (const selector of selectorsToRemove) {
     $(selector).remove()
   }
 
@@ -121,12 +121,12 @@ export async function fetchArticleWithCache(
     cacheTtlMs?: number
   } = {}
 ): Promise<string> {
-  const cacheDir = path.join(
+  const cacheDirectory = path.join(
     ARTICLE_CACHE_BASE_DIR,
     toKebabCase(service.constructor.name)
   )
   const urlHash = crypto.createHash('sha256').update(url).digest('hex')
-  const cachePath = path.join(cacheDir, `${urlHash}.json`)
+  const cachePath = path.join(cacheDirectory, `${urlHash}.json`)
   const cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS
 
   // キャッシュが存在し有効期限内であればキャッシュから返す
@@ -154,15 +154,15 @@ export async function fetchArticleWithCache(
 
   // 記事ページをフェッチする
   logger.info(`🌐 記事ページをフェッチ: ${url}`)
-  const res = await fetch(url, {
+  const response = await fetch(url, {
     headers: options.headers ?? DEFAULT_HEADERS,
   })
-  if (res.status !== 200) {
-    throw new Error(`Failed to fetch article: ${res.status} ${url}`)
+  if (response.status !== 200) {
+    throw new Error(`Failed to fetch article: ${response.status} ${url}`)
   }
 
   const content = extractArticleContent(
-    await res.text(),
+    await response.text(),
     options.contentSelector,
     options.removeSelectors
   )
@@ -174,8 +174,8 @@ export async function fetchArticleWithCache(
   }
 
   // キャッシュディレクトリを作成してキャッシュに保存する
-  if (!fs.existsSync(cacheDir)) {
-    fs.mkdirSync(cacheDir, { recursive: true })
+  if (!fs.existsSync(cacheDirectory)) {
+    fs.mkdirSync(cacheDirectory, { recursive: true })
   }
   const cacheData: ArticleCacheData = {
     url,

--- a/src/utils/deleted-articles-tracker.ts
+++ b/src/utils/deleted-articles-tracker.ts
@@ -40,16 +40,21 @@ export async function fetchDeletedArticlesHistory(): Promise<DeletedArticlesHist
 
   try {
     // キャッシュバスターを追加
-    const res = await fetch(`${DELETED_ARTICLES_HISTORY_URL}?t=${Date.now()}`, {
-      signal: AbortSignal.timeout(10_000),
-    })
+    const response = await fetch(
+      `${DELETED_ARTICLES_HISTORY_URL}?t=${Date.now()}`,
+      {
+        signal: AbortSignal.timeout(10_000),
+      }
+    )
 
-    if (res.status !== 200) {
-      logger.warn(`❌ Failed to fetch deleted articles history: ${res.status}`)
+    if (response.status !== 200) {
+      logger.warn(
+        `❌ Failed to fetch deleted articles history: ${response.status}`
+      )
       return null
     }
 
-    const data = (await res.json()) as DeletedArticlesHistory
+    const data = (await response.json()) as DeletedArticlesHistory
     logger.info(
       `✅ Fetched deleted articles history with ${data.articles.length} articles`
     )

--- a/src/utils/previous-feed.ts
+++ b/src/utils/previous-feed.ts
@@ -55,16 +55,16 @@ export async function getPreviousFeed(serviceName: string): Promise<RssItem[]> {
     const feedUrl = `https://book000.github.io/rss-deliver/${serviceName}.xml`
     logger.info(`📥 Fetching previous feed from ${feedUrl}`)
 
-    const res = await fetch(feedUrl, {
+    const response = await fetch(feedUrl, {
       signal: AbortSignal.timeout(10_000),
     })
 
-    if (res.status !== 200) {
-      logger.warn(`❌ Failed to fetch previous feed: ${res.status}`)
+    if (response.status !== 200) {
+      logger.warn(`❌ Failed to fetch previous feed: ${response.status}`)
       return []
     }
 
-    const text = await res.text()
+    const text = await response.text()
     const parser = new XMLParser({
       ignoreAttributes: false,
     })
@@ -115,22 +115,22 @@ export function inheritPubDate(
   deletedHistory?: DeletedArticlesHistory | null,
   serviceName?: string
 ): Item {
-  const logger = Logger.configure(
-    `utils.inheritPubDate${serviceName ? `.${serviceName}` : ''}`
-  )
-
   // すでにpubDateがある場合はそのまま返す
   if (newItem.pubDate) {
     return newItem
   }
+
+  const logger = Logger.configure(
+    `utils.inheritPubDate${serviceName ? `.${serviceName}` : ''}`
+  )
 
   // IDとして使える値を決定（優先順位: guid > link > title）
   const itemId = (newItem.guid?.['#text'] ?? newItem.link) || newItem.title
 
   // 前回のアイテムから一致するものを検索
   const previousItem = previousItems.find((item) => {
-    const prevId = (item.guid?.['#text'] ?? item.link) || item.title
-    return prevId === itemId
+    const previousId = (item.guid?.['#text'] ?? item.link) || item.title
+    return previousId === itemId
   })
 
   // 前回のpubDateがある場合は引き継ぐ


### PR DESCRIPTION
## 概要

Renovate PR #2502 (`@book000/eslint-config` 1.15.4 -> 1.15.44) の CI 失敗を修正する。

新しい eslint-config が `eslint-plugin-unicorn` の追加ルールを有効化し、既存コードの 54 件のスタイル問題を検出するようになったため（機能追加の PR 自体には非がない）、挙動を変えない機械的な修正で解消した。

## 主な変更

- `unicorn/name-replacements`: `res` -> `response`、`src` -> `source`、`Dev1and` -> `Development1and`（ファイル名 `dev1and.ts` -> `development1and.ts` を含む）など略語の展開
- `unicorn/no-unsafe-string-replacement`: 非リテラルな置換値を関数形式に変更（`template.replace('{{ RSS-FILES }}', () => ...)`）
- `unicorn/prefer-single-replace` / `unicorn/prefer-url-href` / `unicorn/prefer-number-is-safe-integer` / `unicorn/no-non-function-verb-prefix` / `unicorn/consistent-conditional-object-spread`: 自動修正または手動で対応
- `unicorn/no-break-in-nested-loop`: `fish-4koma.ts` の画像サイズ判定ループを `findLargestImage()` メソッドへ抽出
- `unicorn/no-declarations-before-early-exit`: `previous-feed.ts` の `logger` 宣言を早期 return の後に移動

`@book000/eslint-config` 自体のバージョンはこの PR では変更していない（バンプは Renovate PR #2502 側の担当）。

## 確認

- ローカルで `@book000/eslint-config@1.15.44` を一時的に導入し `pnpm run lint`（prettier + eslint + tsc）がクリーンになることを確認
- 元の `1.15.4` に戻した状態でも `pnpm run lint` が通ることを確認（挙動・スタイル両面で退行なし）