### PR TITLE
ci: Update RSS ワークフローを self-hosted ランナーで実行する

### DIFF
--- a/.github/workflows/update-rss.yml
+++ b/.github/workflows/update-rss.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   update-rss:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7


### PR DESCRIPTION
## 概要

`Update RSS` ワークフローの `update-rss` ジョブの実行環境を `ubuntu-latest` から `self-hosted` に変更する。`deploy` ジョブは対象外。

## 背景

直近のログ調査で、`PopTeamEpic` (takecomic.jp への 403) と `PhysicalUpLettuceClub` (lettuceclub.net への 404) の失敗を確認した。GitHub Actions ランナー実機からの診断ワークフローで検証した結果:

- ランナーの所在: `Des Moines, US` / `AS8075 Microsoft Corporation`(日本国外)
- 両サイトともレスポンスヘッダーに `x-cache: Error from cloudfront` が付与されており、オリジンサーバーに到達する前に CloudFront エッジ側でエラーレスポンスが返されている
- 日本国内 IP からは同じリクエストが 200 で成功する

以上から、両サイトが CDN(CloudFront)レイヤーで海外 IP からのアクセスを拒否していることが原因と判断した。`twitter-rss` リポジトリも同様の理由とみられ、既に `self-hosted` ランナーで運用されている。

## 対応

同じセルフホストランナーを共用し、日本国内 IP 経由でアクセスすることで、地域ブロックを回避する。

## 前提・不確実性

- ランナー登録(セルフホストランナーへの本リポジトリのアクセス許可)はユーザー側で別途対応する想定。本 PR はワークフロー定義の変更のみ。
- セルフホストランナー環境が Linux であることを前提としている(`apt-get` を使う既存ステップ、`pnpm` キャッシュキーの `runner.os` 依存)。異なる場合は追加対応が必要。
- `PhysicalUpLettuceClub` / `Rikei2LettuceClub` は、サイト側 HTML 構造変更によるセレクタ不一致で 0 件収集になる別バグが併存しており、本 PR の対象外(未対応)。

## 他エージェントによるレビュー可否

CI 設定のみの変更であり、コードレビューの必要性は低いと判断。必要であれば Codex CLI によるレビューを追加で実施可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)