### PR TITLE
fix: レタスクラブ系サービスのセレクタをサイトのHTML構造変更に追従させる

### DIFF
--- a/src/services/physical-up-lettuce-club.ts
+++ b/src/services/physical-up-lettuce-club.ts
@@ -29,17 +29,28 @@ export default class PhysicalUpLettuceClub extends BaseService {
     }
     const $ = cheerio.load(await res.text())
     const items: Item[] = []
-    for (const index of $('div.l-contents ol.p-items__list li.p-items__item')) {
+    const seenLinks = new Set<string>()
+    // 記事一覧のグリッド表示・「最新話」ハイライト表示のどちらも
+    // 記事詳細への <a href="/news/article/.../display/"> を持つため、
+    // 一覧全体からまとめて拾う
+    for (const index of $('a[href*="/news/article/"]')) {
       const item = $(index)
-      const title = item.find('p.c-item__title').text()
-      let link =
-        'https://www.lettuceclub.net' + (item.find('a').attr('href') ?? '')
-      if (!link.includes('article')) {
+      const href = item.attr('href') ?? ''
+      if (!href.includes('article')) {
         continue
       }
+      let link = 'https://www.lettuceclub.net' + href
       if (link.endsWith('display/')) {
         link = link.replace('display/', '')
       }
+      if (seenLinks.has(link)) {
+        continue
+      }
+      seenLinks.add(link)
+
+      // タイトルは <a> 内の最後の <p> に入っている
+      // (グリッド表示ではジャンルタグの <p> の次にタイトルの <p> が続く)
+      const title = item.find('p').last().text().trim()
 
       const content = await this.getContent(link)
       if (!content) {
@@ -77,19 +88,28 @@ export default class PhysicalUpLettuceClub extends BaseService {
     }
     const $ = cheerio.load(await res.text())
 
+    // 記事ページには広告・関連商品・バナー等の figure/img も混在するため、
+    // URL に含まれる記事 ID を持つ画像パスのみに絞り込む
+    const articleId = /\/article\/(\d+)\//.exec(url)?.[1]
+
     const images: string[] = []
-    for (const index of $('div.l-contents figure img')) {
-      const url = $(index).attr('src') ?? ''
-      if (!url.startsWith('https')) {
+    for (const index of $('figure img')) {
+      const src = $(index).attr('src') ?? ''
+      if (!src.startsWith('https')) {
         continue
       }
-      images.push(url)
+      if (articleId && !src.includes(`/i/N1/${articleId}/`)) {
+        continue
+      }
+      images.push(src)
     }
-    const rawPubDate = $('main time.c-date').attr('datetime') ?? '' // 2021.04.28
-    const pubDate = new Date(rawPubDate.replaceAll('.', '/')).toUTCString()
+
+    // 「公開」日時を持つ <time datetime="..."> を採用する
+    // (ページ末尾のランキングウィジェットにも <time> があるため先頭のものを使う)
+    const rawPubDate = $('time[datetime*="T"]').first().attr('datetime') ?? ''
+    const pubDate = rawPubDate ? new Date(rawPubDate).toUTCString() : ''
     return {
-      // 1つ目はサムネイルなので除外
-      images: images.slice(1),
+      images,
       pubDate,
     }
   }

--- a/src/services/rikei-2-lettuce-club.ts
+++ b/src/services/rikei-2-lettuce-club.ts
@@ -24,19 +24,33 @@ export default class Rikei2LettuceClub extends BaseService {
   async collect(): Promise<CollectResult> {
     const logger = Logger.configure('Rikei2LettuceClub::collect')
     const res = await fetch('https://www.lettuceclub.net/news/serial/12004/')
+    if (!res.ok) {
+      throw new Error(`Failed to fetch: ${res.status}`)
+    }
     const $ = cheerio.load(await res.text())
     const items: Item[] = []
-    for (const index of $('div.l-contents ol.p-items__list li.p-items__item')) {
+    const seenLinks = new Set<string>()
+    // 記事一覧のグリッド表示・「最新話」ハイライト表示のどちらも
+    // 記事詳細への <a href="/news/article/.../display/"> を持つため、
+    // 一覧全体からまとめて拾う
+    for (const index of $('a[href*="/news/article/"]')) {
       const item = $(index)
-      const title = item.find('p.c-item__title').text()
-      let link =
-        'https://www.lettuceclub.net' + (item.find('a').attr('href') ?? '')
-      if (!link.includes('article')) {
+      const href = item.attr('href') ?? ''
+      if (!href.includes('article')) {
         continue
       }
+      let link = 'https://www.lettuceclub.net' + href
       if (link.endsWith('display/')) {
         link = link.replace('display/', '')
       }
+      if (seenLinks.has(link)) {
+        continue
+      }
+      seenLinks.add(link)
+
+      // タイトルは <a> 内の最後の <p> に入っている
+      // (グリッド表示ではジャンルタグの <p> の次にタイトルの <p> が続く)
+      const title = item.find('p').last().text().trim()
 
       const content = await this.getContent(link)
       if (!content) {
@@ -74,19 +88,28 @@ export default class Rikei2LettuceClub extends BaseService {
     }
     const $ = cheerio.load(await res.text())
 
+    // 記事ページには広告・関連商品・バナー等の figure/img も混在するため、
+    // URL に含まれる記事 ID を持つ画像パスのみに絞り込む
+    const articleId = /\/article\/(\d+)\//.exec(url)?.[1]
+
     const images: string[] = []
-    for (const index of $('div.l-contents figure img')) {
-      const url = $(index).attr('src') ?? ''
-      if (!url.startsWith('https')) {
+    for (const index of $('figure img')) {
+      const src = $(index).attr('src') ?? ''
+      if (!src.startsWith('https')) {
         continue
       }
-      images.push(url)
+      if (articleId && !src.includes(`/i/N1/${articleId}/`)) {
+        continue
+      }
+      images.push(src)
     }
-    const rawPubDate = $('main time.c-date').attr('datetime') ?? '' // 2021.04.28
-    const pubDate = new Date(rawPubDate.replaceAll('.', '/')).toUTCString()
+
+    // 「公開」日時を持つ <time datetime="..."> を採用する
+    // (ページ末尾のランキングウィジェットにも <time> があるため先頭のものを使う)
+    const rawPubDate = $('time[datetime*="T"]').first().attr('datetime') ?? ''
+    const pubDate = rawPubDate ? new Date(rawPubDate).toUTCString() : ''
     return {
-      // 1つ目はサムネイルなので除外
-      images: images.slice(1),
+      images,
       pubDate,
     }
   }


### PR DESCRIPTION
## 概要

`PhysicalUpLettuceClub`・`Rikei2LettuceClub`(いずれも lettuceclub.net の同一テンプレートを使用するシリアル記事)が記事を取得できなくなっていた問題を修正する。

## 背景

update-rss のログ確認で `PhysicalUpLettuceClub` の 404 を発見し、原因調査したところ以下の2点が判明した。

1. GitHub Actions ランナー(米国)からのアクセスが CloudFront エッジで地域/ASNブロックされている(`x-cache: Error from cloudfront`)。これは別PR #2597(self-hosted ランナーへの切り替え)で対応済み。
2. lettuceclub.net のHTML構造が変更されており、self-hosted ランナー切り替え後もサイトへ到達さえできれば旧セレクタでは記事を1件も取得できない状態だった。本PRはこの (2) を修正する。

## 修正内容

- 一覧ページ: `div.l-contents ol.p-items__list li.p-items__item` (0件ヒット)を廃止し、`a[href*="/news/article/"]` を直接収集して URL で重複除去する方式に変更
- タイトル: リンク内の `p.c-item__title` (存在しない)ではなく、リンク内最後の `p` 要素から取得
- 詳細ページの画像: `div.l-contents figure img` (0件ヒット。旧セレクタが指していた `l-contents` は新デザインでは無関係な埋め込みランキングウィジェットの一部になっていた)を廃止し、`figure img` を全体から取得したうえで記事ID (`/i/N1/{articleId}/`) を含む src のみに絞り込む方式に変更。広告・関連商品等の画像は自動的に除外される
- 公開日時: `main time.c-date` (`2021.04.28` 形式、要変換)ではなく `time[datetime*="T"]` の先頭要素 (ISO 8601 形式、変換不要)から取得
- `Rikei2LettuceClub` に一覧ページ取得失敗時の `throw` を追加。従来はレスポンスステータスを確認しておらず、エラーページ等を返された場合でも「0件成功」として扱っていた

## 検証

- 実サイトの HTML を取得し、新セレクタでのパース結果を個別に検証(両サービスとも一覧9件・タイトル正常、詳細ページの画像枚数・公開日時が正しく取得できることを確認)
- `pnpm lint` (prettier / eslint / tsc) が通過することを確認
- `pnpm start` を実行し、両サービスとも実際に RSS アイテムが生成されることを確認

## 前提・不確実性

- lettuceclub.net の記事ID (`/i/N1/{articleId}/` 形式) が今後も画像URLの識別子として維持される前提に依存している。サイト側でこの命名規則が変わった場合は再度追従が必要
- 旧コードにあった「先頭の画像はサムネイルなので除外する」処理 (`.slice(1)`) を削除した。新HTMLでは重複するサムネイル画像が確認できず、全画像 (6枚) が本文の意味あるコマ画像であることを alt テキストで確認済みだが、今後別のサムネイル的な画像が紛れ込む可能性は否定できない
- 本PRは #2597 (CI ランナーの self-hosted 化)とは独立しており、CI 設定には触れていない。#2597 がマージされるまでは、GitHub Actions 環境ではこのセレクタ修正が入っても CloudFront ブロックにより到達自体ができない可能性がある

## 他エージェントによるレビュー

ローカルスコープの CSS セレクタ変更・スクレイピングロジックの修正であり、アーキテクチャやモジュール間契約への影響はない。Codex CLI によるコードレビューは任意(必須ではない)と判断。
