### PR TITLE
fix: add explicit limit to date split in pop-team-epic.ts

### DIFF
--- a/src/services/pop-team-epic.ts
+++ b/src/services/pop-team-epic.ts
@@ -754,7 +754,7 @@ export default class PopTeamEpic extends BaseService {
     if (!dateText) {
       return null
     }
-    const [year, month, day] = dateText.split('/')
+    const [year, month, day] = dateText.split('/', 3)
     if (!year || !month || !day) {
       return null
     }


### PR DESCRIPTION
## Summary

Fixes a new `unicorn/prefer-split-limit` ESLint error surfaced by an upcoming `@book000/eslint-config` bump (see Renovate PR #2610).

`parseJstDate` destructures exactly 3 parts (`year`, `month`, `day`) from `dateText.split('/')`, but the split had no explicit limit. `unicorn/prefer-split-limit` wants a limit passed when the result is destructured into a fixed number of parts.

## Changes

- `src/services/pop-team-epic.ts`: `dateText.split('/')` → `dateText.split('/', 3)` (behaviorally identical for well-formed input; ESLint's own `--fix` produced this change).

## Verification

Ran locally against this repo's current lockfile:
- `eslint . -c eslint.config.mjs` — clean
- `tsc` — clean
- `prettier --check src` — clean