### PR TITLE
fix(deps): node-ical を 0.27.1 に更新し型宣言のバグを pnpm patch で修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-promise": "7.3.0",
     "fast-xml-builder": "1.3.0",
     "fast-xml-parser": "5.10.1",
-    "node-ical": "0.26.1",
+    "node-ical": "0.27.1",
     "pdfjs-dist": "6.2.108",
     "prettier": "3.9.6",
     "run-z": "2.1.0",

--- a/patches/node-ical@0.27.1.patch
+++ b/patches/node-ical@0.27.1.patch
@@ -1,0 +1,13 @@
+diff --git a/node-ical.d.ts b/node-ical.d.ts
+index 1d5a12fa7bb792925724f00dee93a86fd7c7ee4e..4ce5721791e478e64d7113199bfd50c0caa8a952 100644
+--- a/node-ical.d.ts
++++ b/node-ical.d.ts
+@@ -109,7 +109,7 @@ declare module 'node-ical' {
+     options: ExpandRecurringEventOptions,
+   ): EventInstance[];
+ 
+-  declare const _default: {
++  const _default: {
+     fromURL: typeof fromURL;
+     parseFile: typeof parseFile;
+     parseICS: typeof parseICS;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  node-ical@0.27.1: c4444a7270176ed7757ab1a7ff14fe38ecc011ff529788dffb57b31459a5213b
+
 importers:
 
   .:
@@ -45,8 +48,8 @@ importers:
         specifier: 5.10.1
         version: 5.10.1
       node-ical:
-        specifier: 0.26.1
-        version: 0.26.1
+        specifier: 0.27.1
+        version: 0.27.1(patch_hash=c4444a7270176ed7757ab1a7ff14fe38ecc011ff529788dffb57b31459a5213b)
       pdfjs-dist:
         specifier: 6.2.108
         version: 6.2.108
@@ -474,10 +477,6 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
-
-  '@js-temporal/polyfill@0.5.1':
-    resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
-    engines: {node: '>=12'}
 
   '@napi-rs/canvas-android-arm64@1.0.2':
     resolution: {integrity: sha512-IMXKVQod0ol4vt3gmClUfXz4JAgHYESGPCUqmH3lQxBoL0K/2greJaQE1HVBVxWWFKfLc4OLZVdxg7kXVyXv+g==}
@@ -1594,9 +1593,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  jsbi@4.3.2:
-    resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
-
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -1723,9 +1719,9 @@ packages:
     resolution: {integrity: sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==}
     engines: {node: '>= 0.4'}
 
-  node-ical@0.26.1:
-    resolution: {integrity: sha512-KoYLpsz7Ga9lPDpt9vy0iKcgcb/9Ix7ICRZd0csLXMl2lZOSONGj7HrcktJFR7Jid1l44Zu1H4k/1nB04rWPgQ==}
-    engines: {node: '>=20'}
+  node-ical@0.27.1:
+    resolution: {integrity: sha512-5fiKuh/h2HrWKzFt20LtRQdjtjdGfijGfDnCfdAEc++SFX9gA6sa7xwj7/BJmRfWtW/NJWBenN4tOJhg0vM3pg==}
+    engines: {node: '>=22'}
 
   node-releases@2.0.50:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
@@ -1931,8 +1927,8 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  rrule-temporal@1.6.0:
-    resolution: {integrity: sha512-tlhiNroletItRVdVP3knk92MCPNdFmPpehQMxf+jSo0CHZpmp1WUsvdVpg2iS++J9+O7/89J64BldN21kbcBqA==}
+  rrule-temporal@2.0.2:
+    resolution: {integrity: sha512-pwe7+pWXKUotQgdudN8W36tFHWf8eH+FbcB5Tl4Zftb4RYpl1hnqMRapizv0s8QlOlC6GEKcVSmITurpSOVZfQ==}
 
   run-z@2.1.0:
     resolution: {integrity: sha512-GGG0odDAOlGc6JvUXjrIiHmS2ZpyAKoJVIEPmSFapkK32ax+V9Q1lRtJFPBjFBZWTVflbkIbwEFTAsexLYxqdw==}
@@ -2111,14 +2107,17 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
-  temporal-polyfill@0.3.2:
-    resolution: {integrity: sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==}
-
-  temporal-spec@0.3.1:
-    resolution: {integrity: sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==}
+  temporal-polyfill@1.0.2:
+    resolution: {integrity: sha512-pTyp/7kfStJQbJ8YOHmcJItkxvOGCZHu3PaVgLvLnxFS7O12EPiWLElnRre/rw77z4TGZX/gvdqMXWn6ispQvA==}
 
   temporal-spec@1.0.0:
     resolution: {integrity: sha512-00Ahj1e1ifaERTMOIIGpOCdOo9IEk2m6GGSMedsn9a2SIsGLdOTbmME1Htv6IM82b6VHrzSUTIVc7YHy6hdhFQ==}
+
+  temporal-spec@1.0.1:
+    resolution: {integrity: sha512-wxVoanmDeavXie1vu2JaQ3WIc3JZnWAOYFBsJyATaVsXsycKYUflGsyBmrRSnoCpZJpwPyr38VpgSUlQ8CbFxg==}
+
+  temporal-utils@1.0.1:
+    resolution: {integrity: sha512-HAixuesxFQIUaQk3ptX2jhfO/FsOkgVkDDMawvp6n/fkB1q6BKfs3lURw9I+pK/2e2e/q/vrLrxmeqauBoyGMQ==}
 
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
@@ -2606,10 +2605,6 @@ snapshots:
     optional: true
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
-
-  '@js-temporal/polyfill@0.5.1':
-    dependencies:
-      jsbi: 4.3.2
 
   '@napi-rs/canvas-android-arm64@1.0.2':
     optional: true
@@ -3940,8 +3935,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  jsbi@4.3.2: {}
-
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -4073,10 +4066,10 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
-  node-ical@0.26.1:
+  node-ical@0.27.1(patch_hash=c4444a7270176ed7757ab1a7ff14fe38ecc011ff529788dffb57b31459a5213b):
     dependencies:
-      rrule-temporal: 1.6.0
-      temporal-polyfill: 0.3.2
+      rrule-temporal: 2.0.2
+      temporal-polyfill: 1.0.2
 
   node-releases@2.0.50: {}
 
@@ -4308,9 +4301,8 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  rrule-temporal@1.6.0:
+  rrule-temporal@2.0.2:
     dependencies:
-      '@js-temporal/polyfill': 0.5.1
       temporal-spec: 1.0.0
 
   run-z@2.1.0:
@@ -4568,13 +4560,16 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  temporal-polyfill@0.3.2:
+  temporal-polyfill@1.0.2:
     dependencies:
-      temporal-spec: 0.3.1
-
-  temporal-spec@0.3.1: {}
+      temporal-spec: 1.0.1
+      temporal-utils: 1.0.1
 
   temporal-spec@1.0.0: {}
+
+  temporal-spec@1.0.1: {}
+
+  temporal-utils@1.0.1: {}
 
   text-hex@1.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,5 @@ allowBuilds:
   sharp: true
 minimumReleaseAgeExclude:
   - '@book000/*'
+patchedDependencies:
+  node-ical@0.27.1: patches/node-ical@0.27.1.patch


### PR DESCRIPTION
## 概要

Renovate PR #2625 (`node-ical` `0.26.1` → `0.27.1`) の CI (`Node CI / node-ci (.)`, `Node CI / Check finished Node CI`) が `tsc` の型エラーで失敗していたための修正 PR です。

## 原因

`node-ical@0.27.1` が同梱する `node-ical.d.ts` は、既に ambient な `declare module 'node-ical'` ブロック内で `declare const _default` を使っており、TypeScript の `TS1038: A 'declare' modifier cannot be used in an already ambient context` エラーになります。npm から `node-ical@0.27.1` を直接取得して確認した限り、node-ical 自身が配布している型宣言ファイルのバグで、本リポジトリのコード側に問題はありません。

本リポジトリの `CLAUDE.md` で `skipLibCheck` の使用が禁止されているため、`tsconfig.json` を変更する代わりに `pnpm patch` でベンダー側の `.d.ts` ファイルから不要な `declare` キーワードのみを取り除く形で修正しました。

## 変更内容

- `node-ical` を `0.26.1` → `0.27.1` に更新(Renovate PR #2625 と同じ更新内容)
- `patches/node-ical@0.27.1.patch` を追加し、`node-ical.d.ts` の `declare const _default` → `const _default` に修正するパッチを `pnpm-workspace.yaml` の `patchedDependencies` に登録
- `pnpm-lock.yaml` を再生成

## 確認事項

- `pnpm lint`(Prettier / ESLint / tsc)がすべてパスすることを確認
- `node-ical` の `fromURL`/`async` 等が実行時に問題なく import・呼び出せることを確認

Renovate PR #2625 はそのまま(このブランチへのコミットはしていません)。

---
🤖 このPRは Renovate PR の CI 修正を目的として自動生成されました。